### PR TITLE
Complex custom non-Uri objects for multi-step binding proof

### DIFF
--- a/Simpler/Control.cpp
+++ b/Simpler/Control.cpp
@@ -9,7 +9,7 @@ using namespace Windows::UI::Xaml::Controls;
 
 namespace winrt
 {
-    xaml_member bind(Uri const& object, hstring const& name)
+    xaml_member bind(Uri const& /*object*/, hstring const& /*name*/)
     {
         return {};
     }
@@ -17,10 +17,48 @@ namespace winrt
 
 struct Member
 {
-    xaml_member bind(hstring const& name)
+    xaml_member bind(hstring const& /*name*/)
     {
         return {};
     }
+};
+
+struct UriThing : xaml_type<UriThing, true, implements>
+{
+    static hstring GetRuntimeClassName() { return L"UriThing"; }
+
+    xaml_member bind(hstring const& name)
+    {
+        if (name == L"Domain")
+        {
+            return m_domain;
+        }
+
+        return {};
+    }
+
+private:
+
+    hstring m_domain{ L"Some string value" };
+};
+
+struct ViewModel : xaml_type<ViewModel, true, implements>
+{
+    static hstring GetRuntimeClassName() { return L"ViewModel"; }
+
+    xaml_member bind(hstring const& name)
+    {
+        if (name == L"Uri")
+        {
+            return m_thing;
+        }
+
+        return {};
+    }
+
+private:
+
+    UriThing m_thing;
 };
 
 struct SampleControl : xaml_user_control<SampleControl>
@@ -38,20 +76,22 @@ struct SampleControl : xaml_user_control<SampleControl>
 
     xaml_member bind(hstring const& name)
     {
-        if (name == L"Uri")
-        {
-            return m_uri;
-        }
+        name;
 
-        if (name == L"Counter")
-        {
-            return m_counter;
-        }
+        //if (name == L"Uri")
+        //{
+        //    return m_uri;
+        //}
 
-        if (name == L"Member")
-        {
-            return m_member;
-        }
+        //if (name == L"Counter")
+        //{
+        //    return m_counter;
+        //}
+
+        //if (name == L"Member")
+        //{
+        //    return m_member;
+        //}
 
         //if (name == L"Text")
         //{
@@ -68,11 +108,8 @@ struct SampleControl : xaml_user_control<SampleControl>
 
     SampleControl() : base_type(L"ms-appx:///Control.xaml")
     {
-        DataContext(*this);
-        Loaded([&](auto && ...)
-            {
-                UpdateAsync();
-            });
+        DataContext(make<ViewModel>());
+        Loaded([&](auto && ...) { UpdateAsync(); });
     }
 
     fire_and_forget UpdateAsync()

--- a/Simpler/Control.cpp
+++ b/Simpler/Control.cpp
@@ -3,14 +3,33 @@
 
 using namespace std::literals;
 using namespace winrt;
+using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 using namespace Windows::UI::Xaml::Controls;
+
+namespace winrt
+{
+    xaml_member bind(Uri const& object, hstring const& name)
+    {
+        return {};
+    }
+}
+
+struct Member
+{
+    xaml_member bind(hstring const& name)
+    {
+        return {};
+    }
+};
 
 struct SampleControl : xaml_user_control<SampleControl>
 {
     int m_counter{};
     hstring m_text;
-    IObservableVector<boxed_value> m_list{ observable_vector<boxed_value>() };
+    IObservableVector<int> m_list{ observable_vector<int>() };
+    Uri m_uri{ L"http://kennykerr.ca/about" };
+    Member m_member;
 
     static hstring type_name()
     {
@@ -19,20 +38,30 @@ struct SampleControl : xaml_user_control<SampleControl>
 
     xaml_member bind(hstring const& name)
     {
+        if (name == L"Uri")
+        {
+            return m_uri;
+        }
+
         if (name == L"Counter")
         {
             return m_counter;
         }
 
-        if (name == L"Text")
+        if (name == L"Member")
         {
-            return m_text;
+            return m_member;
         }
 
-        if (name == L"List")
-        {
-            return m_list;
-        }
+        //if (name == L"Text")
+        //{
+        //    return m_text;
+        //}
+
+        //if (name == L"List")
+        //{
+        //    return m_list;
+        //}
 
         return {};
     }
@@ -40,7 +69,10 @@ struct SampleControl : xaml_user_control<SampleControl>
     SampleControl() : base_type(L"ms-appx:///Control.xaml")
     {
         DataContext(*this);
-        Loaded([&](auto && ...) { UpdateAsync(); });
+        Loaded([&](auto && ...)
+            {
+                UpdateAsync();
+            });
     }
 
     fire_and_forget UpdateAsync()

--- a/Simpler/Control.xaml
+++ b/Simpler/Control.xaml
@@ -6,10 +6,10 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock
+        <!--<TextBlock
             Grid.Row="0"
             FontSize="48"
-            Text="{Binding Counter}" />
+            Text="{Binding Counter}" />-->
         <TextBlock
             Grid.Row="1"
             FontSize="48"

--- a/Simpler/Control.xaml
+++ b/Simpler/Control.xaml
@@ -10,23 +10,9 @@
             Grid.Row="0"
             FontSize="48"
             Text="{Binding Counter}" />
-        <TextBox
+        <TextBlock
             Grid.Row="1"
             FontSize="48"
-            Text="{Binding Text, Mode=TwoWay}" />
-        <TextBox
-            Grid.Row="2"
-            FontSize="48"
-            IsReadOnly="true"
-            Text="{Binding Text}" />
-        <ScrollViewer Grid.Row="3">
-            <ListView ItemsSource="{Binding List}">
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding}" FontSize="48" />
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
-        </ScrollViewer>
+            Text="{Binding Uri.Domain}" />
     </Grid>
 </UserControl>

--- a/Simpler/Simpler.vcxproj
+++ b/Simpler/Simpler.vcxproj
@@ -129,7 +129,7 @@
     <ClCompile>
       <AdditionalOptions>/bigobj /await</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\git\xlang\_build\Windows\x64\Debug\tool\cppwinrt\;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <CompileAsWinRT>false</CompileAsWinRT>
       <LanguageStandard>stdcpplatest</LanguageStandard>
@@ -161,7 +161,7 @@
     <ClCompile>
       <AdditionalOptions>/bigobj /await</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\git\xlang\_build\Windows\x64\Debug\tool\cppwinrt\;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <CompileAsWinRT>false</CompileAsWinRT>
       <LanguageStandard>stdcpplatest</LanguageStandard>
@@ -192,7 +192,7 @@
     <ClCompile>
       <AdditionalOptions>/bigobj /await</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\git\xlang\_build\Windows\x64\Debug\tool\cppwinrt\;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <CompileAsWinRT>false</CompileAsWinRT>
       <LanguageStandard>stdcpplatest</LanguageStandard>
@@ -224,7 +224,7 @@
     <ClCompile>
       <AdditionalOptions>/bigobj /await</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\git\xlang\_build\Windows\x64\Debug\tool\cppwinrt\;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <CompileAsWinRT>false</CompileAsWinRT>
       <LanguageStandard>stdcpplatest</LanguageStandard>
@@ -255,7 +255,7 @@
     <ClCompile>
       <AdditionalOptions>/bigobj /await</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\git\xlang\_build\Windows\x64\Debug\tool\cppwinrt\;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <CompileAsWinRT>false</CompileAsWinRT>
       <LanguageStandard>stdcpplatest</LanguageStandard>
@@ -287,7 +287,7 @@
     <ClCompile>
       <AdditionalOptions>/bigobj /await</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\git\xlang\_build\Windows\x64\Debug\tool\cppwinrt\;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <CompileAsWinRT>false</CompileAsWinRT>
       <LanguageStandard>stdcpplatest</LanguageStandard>

--- a/Simpler/pch.h
+++ b/Simpler/pch.h
@@ -2,8 +2,8 @@
 
 #include "winrt/Windows.ApplicationModel.Activation.h"
 #include "winrt/Windows.Foundation.Collections.h"
+#include "winrt/Windows.UI.Core.h"
 #include "winrt/Windows.UI.Xaml.Controls.h"
 #include "winrt/Windows.UI.Xaml.Data.h"
 #include "winrt/Windows.UI.Xaml.Markup.h"
-#include "winrt/coroutine.h"
 #include <functional>

--- a/Simpler/xaml.h
+++ b/Simpler/xaml.h
@@ -262,6 +262,11 @@ namespace winrt
 
         static inline D* s_last_type;
 
+        xaml_type()
+        {
+            s_last_type = static_cast<D*>(this);
+        }
+
         xaml_type(hstring const& uri)
         {
             Windows::UI::Xaml::Application::LoadComponent(*this, Windows::Foundation::Uri(uri));

--- a/Simpler/xaml.h
+++ b/Simpler/xaml.h
@@ -12,12 +12,31 @@ namespace winrt
         return single_threaded_observable_vector<T, Allocator>(std::forward<std::vector<T, Allocator>>(values));
     }
 
+    struct xaml_member;
+
+    template <typename T>
+    class has_bind
+    {
+        template <typename U, typename = decltype(std::declval<U>().bind(L""))> static constexpr bool get_value(int) { return true; }
+        template <typename> static constexpr bool get_value(...) { return false; }
+
+    public:
+
+        static constexpr bool value = get_value<T>(0);
+    };
+
+    template <typename T, std::enable_if_t<has_bind<T>::value, int> = 0>
+    auto bind(T&& object, hstring const& name)
+    {
+        return object.bind(name);
+    }
+
     struct xaml_member
     {
         xaml_member() noexcept {}
 
         template <typename T>
-        xaml_member(T& value) : m_accessor(new accessor<T>(value))
+        xaml_member(T& value) : m_accessor(std::make_shared<accessor<T>>(value))
         {
         }
 
@@ -39,12 +58,39 @@ namespace winrt
             }
         }
 
+        xaml_member bind(hstring const& name) const
+        {
+            if (m_accessor)
+            {
+                return m_accessor->bind(name);
+            }
+
+            return {};
+        }
+
+        bool can_bind() const noexcept
+        {
+            if (m_accessor)
+            {
+                return m_accessor->can_bind();
+            }
+
+            return false;
+        }
+
+        explicit operator bool() const noexcept
+        {
+            return static_cast<bool>(m_accessor);
+        }
+
     private:
 
         struct accessor_abi
         {
             virtual inspectable get() = 0;
             virtual void put(inspectable const&) = 0;
+            virtual xaml_member bind(hstring const& name) = 0;
+            virtual bool can_bind() noexcept = 0;
         };
 
         template <typename T>
@@ -56,12 +102,35 @@ namespace winrt
 
             inspectable get() final
             {
-                return box_value(m_value);
+                if constexpr (impl::has_category_v<T>)
+                {
+                    return box_value(m_value);
+                }
+
+                return {};
             }
 
-            void put(inspectable const& value) final
+            void put([[maybe_unused]] inspectable const& value) final
             {
-                m_value = unbox_value<T>(value);
+                if constexpr (impl::has_category_v<T>)
+                {
+                    m_value = unbox_value<T>(value);
+                }
+            }
+
+            xaml_member bind([[maybe_unused]] hstring const& name) final
+            {
+                if constexpr (std::is_compound_v<T>)
+                {
+                    return winrt::bind(m_value, name);
+                }
+
+                return {};
+            }
+
+            bool can_bind() noexcept final
+            {
+                return std::is_class_v<T>;
             }
 
         private:
@@ -69,7 +138,7 @@ namespace winrt
             T& m_value;
         };
 
-        std::unique_ptr<accessor_abi> m_accessor;
+        std::shared_ptr<accessor_abi> m_accessor;
     };
 
     struct xaml_registry
@@ -181,9 +250,12 @@ namespace winrt
 
         using base_type = xaml_type<D, R, B, I...>;
 
+        static inline D* s_last_type;
+
         xaml_type(hstring const& uri)
         {
             Windows::UI::Xaml::Application::LoadComponent(*this, Windows::Foundation::Uri(uri));
+            s_last_type = static_cast<D*>(this);
         }
 
         void property_changed(hstring const& name)
@@ -195,9 +267,10 @@ namespace winrt
 
         struct xaml_member_instance : implements<xaml_member_instance, Windows::UI::Xaml::Markup::IXamlMember>
         {
-            xaml_member_instance(hstring const& name) :
+            xaml_member_instance(D* instance, hstring const& name) :
                 m_name(name)
             {
+                m_instance.copy_from(instance);
             }
 
             hstring Name() const
@@ -205,20 +278,29 @@ namespace winrt
                 return m_name;
             }
 
-            Windows::UI::Xaml::Markup::IXamlType Type() const
+            Windows::UI::Xaml::Markup::IXamlType Type()
             {
+                resolve();
+
+                if (auto member = m_member.can_bind())
+                {
+                    return make<member_type>(m_member, m_name);
+                }
+
                 return nullptr;
             }
 
             inspectable GetValue(inspectable const& instance)
             {
-                resolve(instance);
+                WINRT_ASSERT(instance == *m_instance);
+                resolve();
                 return m_member.get();
             }
 
             void SetValue(inspectable const& instance, inspectable const& value)
             {
-                resolve(instance);
+                WINRT_ASSERT(instance == *m_instance);
+                resolve();
                 m_member.put(value);
                 m_instance->property_changed(m_name);
             }
@@ -228,25 +310,128 @@ namespace winrt
                 return false;
             }
 
-            bool IsAttachable() const noexcept { return {}; }
-            bool IsDependencyProperty() const noexcept { return {}; }
-            Windows::UI::Xaml::Markup::IXamlType TargetType() const noexcept { return {}; }
+            bool IsAttachable() const noexcept
+            {
+                return {};
+            }
+
+            bool IsDependencyProperty() const noexcept
+            {
+                return {};
+            }
+
+            Windows::UI::Xaml::Markup::IXamlType TargetType() const noexcept
+            {
+                return {};
+            }
 
         private:
 
-            void resolve(inspectable const& instance)
+            struct member_type : implements<member_type, Windows::UI::Xaml::Markup::IXamlType>
             {
-                if (m_key != get_abi(instance))
+                member_type(xaml_member const& member, hstring const& name) :
+                    m_member(member),
+                    m_name(name)
                 {
-                    m_key = get_abi(instance);
-                    m_instance = get_self<D>(instance.as<Windows::UI::Xaml::Data::INotifyPropertyChanged>())->get_strong();
-                    m_member = m_instance->bind(m_name);
+                }
+
+                hstring FullName() const
+                {
+                    return L"";
+                }
+
+                auto ActivateInstance() const
+                {
+                    return nullptr;
+                }
+
+                auto BaseType() const
+                {
+                    return nullptr;
+                }
+
+                bool IsConstructible() const
+                {
+                    return true;
+                }
+
+                Windows::UI::Xaml::Interop::TypeName UnderlyingType() const
+                {
+                    return { m_name, Windows::UI::Xaml::Interop::TypeKind::Custom };
+                }
+
+                bool IsBindable() const
+                {
+                    return true;
+                }
+
+                Windows::UI::Xaml::Markup::IXamlMember GetMember(hstring const& name) const
+                {
+                    name;
+                    return nullptr;
+                }
+
+                Windows::UI::Xaml::Markup::IXamlMember ContentProperty() const noexcept
+                {
+                    return {};
+                }
+                bool IsArray() const noexcept
+                {
+                    return {};
+                }
+                bool IsCollection() const noexcept
+                {
+                    return {};
+                }
+                bool IsDictionary() const noexcept
+                {
+                    return {};
+                }
+                bool IsMarkupExtension() const noexcept
+                {
+                    return {};
+                }
+                Windows::UI::Xaml::Markup::IXamlType ItemType() const noexcept
+                {
+                    return {};
+                }
+                Windows::UI::Xaml::Markup::IXamlType KeyType() const noexcept
+                {
+                    return {};
+                }
+
+                inspectable CreateFromString(hstring const& value) const noexcept
+                {
+                    value;
+                    return {};
+                }
+
+                void AddToVector(inspectable const&, inspectable const&) const noexcept
+                {
+                }
+                void AddToMap(inspectable const&, inspectable const&, inspectable const&) const noexcept
+                {
+                }
+                void RunInitializer() const noexcept
+                {
+                }
+
+            private:
+
+                xaml_member m_member;
+                hstring const m_name;
+            };
+
+            void resolve()
+            {
+                if (!m_member)
+                {
+                    m_member = bind(*m_instance, m_name);
                 }
             }
 
-            hstring const m_name;
-            void* m_key{};
             com_ptr<D> m_instance;
+            hstring const m_name;
             xaml_member m_member;
         };
 
@@ -284,7 +469,7 @@ namespace winrt
 
             Windows::UI::Xaml::Markup::IXamlMember GetMember(hstring const& name) const
             {
-                return make<xaml_member_instance>(name);
+                return make<xaml_member_instance>(s_last_type, name);
             }
 
             Windows::UI::Xaml::Markup::IXamlMember ContentProperty() const noexcept { return {}; }
@@ -294,7 +479,13 @@ namespace winrt
             bool IsMarkupExtension() const noexcept { return {}; }
             Windows::UI::Xaml::Markup::IXamlType ItemType() const noexcept { return {}; }
             Windows::UI::Xaml::Markup::IXamlType KeyType() const noexcept { return {}; }
-            inspectable CreateFromString(hstring const&) const noexcept { return {}; }
+
+            inspectable CreateFromString(hstring const& value) const noexcept
+            {
+                value;
+                return {};
+            }
+
             void AddToVector(inspectable const&, inspectable const&) const noexcept { }
             void AddToMap(inspectable const&, inspectable const&, inspectable const&) const noexcept { }
             void RunInitializer() const noexcept { }

--- a/Simpler/xaml.h
+++ b/Simpler/xaml.h
@@ -155,6 +155,16 @@ namespace winrt
             return true;
         }
 
+        static bool add_once(Windows::UI::Xaml::Markup::IXamlType const& type)
+        {
+            registry().add_type(type.FullName(), [type]
+                {
+                    return type;
+                });
+
+            return true;
+        }
+
         static Windows::UI::Xaml::Markup::IXamlType get(hstring const& name)
         {
             return registry().get_type(name);
@@ -337,7 +347,7 @@ namespace winrt
 
                 hstring FullName() const
                 {
-                    return L"";
+                    return m_name;
                 }
 
                 auto ActivateInstance() const
@@ -345,7 +355,7 @@ namespace winrt
                     return nullptr;
                 }
 
-                auto BaseType() const
+                Windows::UI::Xaml::Markup::IXamlType BaseType() const
                 {
                     return nullptr;
                 }
@@ -357,6 +367,7 @@ namespace winrt
 
                 Windows::UI::Xaml::Interop::TypeName UnderlyingType() const
                 {
+                    xaml_registry::add_once(*this);
                     return { m_name, Windows::UI::Xaml::Interop::TypeKind::Custom };
                 }
 


### PR DESCRIPTION
replace Uri binding with custom object to prove IXMP  multi step binding paths work with fully custom xaml_types.

This current code fails because the "get" accessor for the ViewModel's property "Uri" fails to return a value due to failure of the "if" statement below. 

            inspectable get() final
            {
                if constexpr (impl::has_category_v<T>)
                {
                    return box_value(m_value);
                }

                return {};
            }
