### PR TITLE
Attempt a templated control that uses a custom DependencyProperty

### DIFF
--- a/Simpler/App.cpp
+++ b/Simpler/App.cpp
@@ -14,6 +14,16 @@ struct MainPage : xaml_page<MainPage>
 
 struct App : xaml_app<App>
 {
+    App()
+    {
+        UnhandledException(
+            [](Windows::Foundation::IInspectable const&, Windows::UI::Xaml::UnhandledExceptionEventArgs const& e)
+            {
+                hstring message{ e.Message() };
+                (void)message;
+            });
+    }
+
     void OnLaunched(LaunchActivatedEventArgs const&)
     {
         auto window = Window::Current();

--- a/Simpler/Control.xaml
+++ b/Simpler/Control.xaml
@@ -1,54 +1,20 @@
-﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="using:Sample">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <TextBlock
-            Grid.Row="0"
-            FontSize="24"
-            Text="{Binding Counter}" />
-        <TextBlock
-            Grid.Row="1"
-            FontSize="24"
-            Text="{Binding Uri.Domain}" />
-        <TextBox
-            Grid.Row="2"
-            FontSize="24"
-            Text="{Binding Text, Mode=TwoWay}" />
-        <TextBox
-            Grid.Row="3"
-            FontSize="24"
-            IsReadOnly="true"
-            Text="{Binding Text}" />
-        <TextBox
-            Grid.Row="4"
-            FontSize="24"
-            Text="{Binding Visual.Comment, Mode=TwoWay}" />
-        <TextBox
-            Grid.Row="5"
-            FontSize="24"
-            IsReadOnly="true"
-            Text="{Binding Visual.Comment}" />
-        <TextBox
-            Grid.Row="6"
-            FontSize="24"
-            Text="{Binding Clip.BottomInset, Mode=TwoWay}" />
-        <TextBox
-            Grid.Row="7"
-            FontSize="24"
-            IsReadOnly="true"
-            Text="{Binding Clip.BottomInset}" />
-    </Grid>
+﻿<UserControl
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Sample"
+    >
+
+    <StackPanel>
+        <TextBlock FontSize="24" Text="{Binding Counter}" />
+        <TextBlock FontSize="24" Text="{Binding Uri.Domain}" />
+        <TextBox FontSize="24" Text="{Binding Text, Mode=TwoWay}" />
+        <TextBox FontSize="24" IsReadOnly="true" Text="{Binding Text}" />
+        <TextBox FontSize="24" Text="{Binding Visual.Comment, Mode=TwoWay}" />
+        <TextBox FontSize="24" IsReadOnly="true" Text="{Binding Visual.Comment}" />
+        <TextBox FontSize="24" Text="{Binding Clip.BottomInset, Mode=TwoWay}" />
+        <TextBox FontSize="24" IsReadOnly="true" Text="{Binding Clip.BottomInset}" />
+
+        <local:CustomDPControl />
+    </StackPanel>
 
 </UserControl>

--- a/Simpler/CustomDPControl.xaml
+++ b/Simpler/CustomDPControl.xaml
@@ -1,0 +1,16 @@
+﻿<Control x:Class="Sample.CustomDPControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Sample"
+    >
+
+    <Control.Template>
+        <ControlTemplate TargetType="local:CustomDPControl" >
+            <Grid
+                Width="200"
+                Height="200"
+                Background="{Binding SelectedBrush, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+        </ControlTemplate>
+    </Control.Template>
+
+</Control>

--- a/Simpler/CustomDPControl.xaml.cpp
+++ b/Simpler/CustomDPControl.xaml.cpp
@@ -1,0 +1,60 @@
+﻿#include "pch.h"
+#include "winrt/xaml.h"
+
+using namespace winrt;
+
+using namespace Windows::UI;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Interop;
+using namespace Windows::UI::Xaml::Media;
+
+namespace Simple
+{
+    struct CustomDPControl : xaml_control<CustomDPControl>
+    {
+        static hstring type_name() { return L"Sample.CustomDPControl"; }
+
+        SolidColorBrush GetSelectedBrush()
+        {
+            return GetValue(CustomDPControl::SelectedBrushProperty).as<SolidColorBrush>();
+        }
+        void SetSelectedBrush(SolidColorBrush const& value)
+        {
+            SetValue(CustomDPControl::SelectedBrushProperty, value);
+        }
+
+        CustomDPControl() : base_type(L"ms-appx:///CustomDPControl.xaml")
+        {
+            SetSelectedBrush(SolidColorBrush(Colors::Green()));
+        }
+
+        xaml_binding bind(hstring const& name)
+        {
+            if (name == L"SelectedBrush")
+            {
+                // does this capture strong refs?
+                return xaml_binding(
+                    [this] {
+                        return GetSelectedBrush();
+                    },
+                    [this] (SolidColorBrush const& value) {
+                        SetSelectedBrush(value);
+                    });
+            }
+
+            return {};
+        }
+
+    private:
+
+        static DependencyProperty SelectedBrushProperty;
+    };
+
+    DependencyProperty CustomDPControl::SelectedBrushProperty = DependencyProperty::Register(
+        L"SelectedBrush", // name
+        xaml_typename<SolidColorBrush>(), // propertyType
+        { CustomDPControl::type_name(), TypeKind::Metadata }, // ownerType
+        nullptr // typeMetadata
+        //PropertyMetadata(SolidColorBrush(Colors::Green())) // typeMetadata
+        );
+}

--- a/Simpler/Simpler.vcxproj
+++ b/Simpler/Simpler.vcxproj
@@ -332,6 +332,9 @@
   <ItemGroup>
     <ClCompile Include="App.cpp" />
     <ClCompile Include="Control.cpp" />
+    <ClCompile Include="CustomDPControl.xaml.cpp">
+      <DependentUpon>CustomDPControl.xaml</DependentUpon>
+    </ClCompile>
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
@@ -365,6 +368,18 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
       <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="CustomDPControl.xaml">
+      <SubType>Designer</SubType>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <FileType>Document</FileType>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Simpler/Simpler.vcxproj.filters
+++ b/Simpler/Simpler.vcxproj.filters
@@ -63,4 +63,7 @@
       <Filter>Build</Filter>
     </AppxManifest>
   </ItemGroup>
+  <ItemGroup>
+    <Page Include="CustomDPControl.xaml" />
+  </ItemGroup>
 </Project>

--- a/Simpler/pch.h
+++ b/Simpler/pch.h
@@ -1,13 +1,16 @@
 ﻿#pragma once
 
-#include "winrt/Windows.Foundation.h"
-#include "winrt/Windows.UI.Xaml.Controls.h"
-#include "winrt/Windows.UI.Xaml.Data.h"
-#include "winrt/Windows.UI.Xaml.Interop.h"
-#include "winrt/Windows.UI.Xaml.Markup.h"
-
 #include "winrt/Windows.ApplicationModel.Activation.h"
+
+#include "winrt/Windows.Foundation.h"
 #include "winrt/Windows.Foundation.Collections.h"
+
 #include "winrt/Windows.UI.Composition.h"
 #include "winrt/Windows.UI.Core.h"
+
+#include "winrt/Windows.UI.Xaml.Controls.h"
+#include "winrt/Windows.UI.Xaml.Data.h"
 #include "winrt/Windows.UI.Xaml.Hosting.h"
+#include "winrt/Windows.UI.Xaml.Interop.h"
+#include "winrt/Windows.UI.Xaml.Markup.h"
+#include "winrt/Windows.UI.Xaml.Media.h"

--- a/Simpler/winrt/xaml.h
+++ b/Simpler/winrt/xaml.h
@@ -723,5 +723,8 @@ namespace winrt
 
     template <typename D, typename... I>
     using xaml_user_control = xaml_type<D, true, Windows::UI::Xaml::Controls::UserControlT, I...>;
+
+    template <typename D, typename... I>
+    using xaml_control = xaml_type<D, true, Windows::UI::Xaml::Controls::ControlT, I...>;
 }
 #endif


### PR DESCRIPTION
This is my attempt to create a custom control (Based on Control not UserControl because UserControl is dumb if you don't have the XamlCompiler). I was able to get everything compiling and running, but the template generated xaml_member never calls my custom getter and setter methods I return in the bind() method. I don't know why. If we can figure out how to get this working, then I would continue to investigate custom Attached Dependency Properties.